### PR TITLE
fix: gradle wrapper

### DIFF
--- a/module/gradle/gradle.go
+++ b/module/gradle/gradle.go
@@ -59,14 +59,14 @@ func (i *Inspector) Inspect(dir string) ([]base.Module, error) {
 	return rs, nil // todo
 }
 
+var gradleBuildFiles = []string{"build.gradle", "build.gradle.kts", "settings.gradle", "settings.gradle.kts"}
+
 func (i *Inspector) CheckDir(dir string) bool {
-	info, e := os.Stat(filepath.Join(dir, "build.gradle"))
-	if e == nil && !info.IsDir() {
-		return true
-	}
-	info, e = os.Stat(filepath.Join(dir, "build.gradle.kts"))
-	if e == nil && !info.IsDir() {
-		return true
+	for _, it := range gradleBuildFiles {
+		info, e := os.Stat(filepath.Join(dir, it))
+		if e == nil && !info.IsDir() {
+			return true
+		}
 	}
 	return false
 }

--- a/module/gradle/gradle_info.go
+++ b/module/gradle/gradle_info.go
@@ -24,7 +24,29 @@ func (g *GradleInfo) String() string {
 }
 
 func evalGradleInfo(dir string) (*GradleInfo, error) {
-	info, e := execWrappedGradleInfo(dir)
+	/**
+	1.
+	由于 ../../inspector/managed_inspect.go:35 使用了filepath.WalkDir
+	这里必然是/xx/current，所以 filepath.Split 方法必然返回dir和name
+
+	2.
+	根据gradle wrapper的介绍，执行gradle wrapper命令后，目录结构如下：
+	.
+	├── a-subproject
+	│   └── build.gradle
+	├── settings.gradle
+	├── gradle
+	│   └── wrapper
+	│       ├── gradle-wrapper.jar
+	│       └── gradle-wrapper.properties
+	├── gradlew
+	└── gradlew.bat
+	所以，需要向上一级，才能正确访问gradlew/gradlew.bat
+	https://docs.gradle.org/current/userguide/gradle_wrapper.html
+	 */
+	gradlewDir , name := filepath.Split(dir)
+	logger.Debug.Println("to gradlew.dir=%s,name=%s", gradlewDir, name)
+	info, e := execWrappedGradleInfo(gradlewDir)
 	if e != nil {
 		logger.Debug.Println("check gradle wrapper failed.", e.Error())
 	} else {


### PR DESCRIPTION
机器：MacBook Pro (13-inch, M1, 2020)

 OS ：macOS Monterey 12.3.1 (21E258)

问题描述：gradle工程，没有安装gradle
（下载、解压后，通过绝对路径初始化工程`/tools/gradle/7.4.2/bin/gradle wrapper`，没有添加到PATH中）

扫描不到依赖，排查logs发现输出：

`2022-05-16T16:37:33+08:00 WARN gradle/gradle_info.go:89 Chmod wrapper 0755 failed.exit status 1/code/app/gradlew`

gradlew在工程中的的实际位置是：`/code/gradlew`

按照[gradle官网描述](https://docs.gradle.org/current/userguide/gradle_wrapper.html)，执行gradle wrapper命令后，目录结构如下：
	.
       ├── a-subproject
        │   └── build.gradle
       ├── settings.gradle
       ├── gradle
        │   └── wrapper
        │       ├── gradle-wrapper.jar
        │       └── gradle-wrapper.properties
       ├── gradlew
      └── gradlew.bat
所以，在`module/gradle/gradle_info.go:49`需要向上一级，才能正确访问gradlew/gradlew.bat
