### PR TITLE
fix:优化执行auth login/logout跳过token读取以及httpClient初始化

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -95,6 +95,9 @@ func preRun(cmd *cobra.Command, args []string) error {
 	}
 
 	env.ConfigureServerBaseUrl(CliServerAddressOverride)
+	if cmd.Parent().Use == "auth" && strings.Contains(cmd.Use, "log") {
+		return nil
+	}
 	api.C = api.NewClient()
 	api.C.Token = conf.APIToken()
 	return nil


### PR DESCRIPTION
preRun函数每次都会优先执行，初始化httpClient以及读取token，
在auth login写入token、logout注销token时应该不需要以上功能，
判断command use，如果请求是auth[login/logout]将不执行httpClient初始化、token读取，提升程序性能。
