### PR TITLE
fix:简化检测python pip版本代码以及修复pip包版本号遗漏bug

### DIFF
--- a/module/python/pip_utils.go
+++ b/module/python/pip_utils.go
@@ -2,6 +2,7 @@ package python
 
 import (
 	"context"
+	"fmt"
 	"github.com/murphysecurity/murphysec/errors"
 	"github.com/murphysecurity/murphysec/model"
 	"github.com/murphysecurity/murphysec/utils"
@@ -12,23 +13,18 @@ var ErrPipListFailed = errors.New("pip list execution failed")
 var ErrNoPipCommand = errors.New("pip command not found")
 
 func locatePipCommand(ctx context.Context) string {
-	var logger = utils.UseLogger(ctx)
+	var (
+		logger     = utils.UseLogger(ctx)
+		pipVerList = []string{"pip", "pip3", "pip2"}
+	)
 	logger.Debug("Trying to locate pip command...")
-	path, e := exec.LookPath("pip")
-	if e == nil {
-		return path
+	for _, pipVer := range pipVerList {
+		path, e := exec.LookPath(pipVer)
+		if e == nil {
+			return path
+		}
+		logger.Debug(fmt.Sprintf("%v not found", pipVer))
 	}
-	logger.Debug("pip not found")
-	path, e = exec.LookPath("pip3")
-	if e == nil {
-		return path
-	}
-	logger.Debug("pip3 not found")
-	path, e = exec.LookPath("pip2")
-	if e == nil {
-		return path
-	}
-	logger.Debug("pip2 not found")
 	return ""
 }
 

--- a/module/python/python.go
+++ b/module/python/python.go
@@ -189,7 +189,7 @@ func (i Inspector) InspectProject(ctx context.Context) error {
 
 func mergeComponentVersionOnly(target map[string]string, deps []model.Dependency) {
 	for _, it := range deps {
-		v, ok := target[it.Name]
+		v, ok := target[strings.ToLower(it.Name)]
 		if v == "" && ok && it.Version != "" {
 			target[it.Name] = it.Version
 		}


### PR DESCRIPTION
1.简化python pip版本检测代码([module/python/pip_utils.go](https://github.com/murphysecurity/murphysec/compare/master...xxddpac:murphysec:fix?expand=1#diff-5e3fcea900ce4df63ac31089bef7ecf88b2c8406bf7b7aebc0367fad705c5a30))


2.在检测python项目未匹配到requirements包文件进行深度扫描时，发现有的包只有名字没有版本号，
本地执行pip命令某些包名首字母是大写，而从py文件获取的import/from 包名是小写，(如flask，py文件获取结果小写，pip list获取结果Flask)，导致版本号缺失影响云端检测结果。
将pip list执行的结果转换小写对比，尽可能避免版本号丢失问题[module/python/python.go](https://github.com/murphysecurity/murphysec/compare/master...xxddpac:murphysec:fix?expand=1#diff-62dfa7eeeea8b18f707eb87b948424bccad02536aafe375e09c04b30f6a43f88)