### PR TITLE
fix: 优化部分python项目包依赖文件扫描跳过问题

### DIFF
--- a/module/python/python.go
+++ b/module/python/python.go
@@ -115,7 +115,7 @@ func scanDepFile(ctx context.Context, dir string) (bool, error) {
 			continue
 		}
 	}
-	logger.Info(fmt.Sprintf("total found pipManagerFiles:%d", len(waitingScanPipManagerFiles)))
+	logger.Info(fmt.Sprintf("total found pipManagerFiles: %d", len(waitingScanPipManagerFiles)))
 	for entryName, fp := range waitingScanPipManagerFiles {
 		logger.Info("start readRequirements...", zap.String("name", entryName), zap.String("relativePath", fp))
 		deps, e := readRequirements(fp)

--- a/module/python/python.go
+++ b/module/python/python.go
@@ -11,6 +11,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -49,12 +50,30 @@ func (i Inspector) CheckDir(dir string) bool {
 	return false
 }
 
+func parseDockerFile(dir, path string, m map[string]string) {
+	// find all PipManagerFiles from dockerfile
+	var regexpToFindPipManagerFiles = `.*?pip.*?install.*?-r[ ]*(.*?)\s+`
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	result := regexp.MustCompile(regexpToFindPipManagerFiles).FindAllStringSubmatch(string(data), -1)
+	for _, item := range result {
+		if len(item) != 2 {
+			continue
+		}
+		m[item[1]] = filepath.Join(dir, item[1])
+	}
+}
+
 func scanDepFile(ctx context.Context, dir string) (bool, error) {
 	var logger = utils.UseLogger(ctx)
 	var found = false
 	var task = model.UseInspectorTask(ctx)
 
 	var tomlFile = filepath.Join(dir, "pyproject.toml")
+	var waitingScanPipManagerFiles = make(map[string]string)
 	if utils.IsFile(tomlFile) {
 		list, e := tomlBuildSysFile(ctx, tomlFile)
 		if e != nil {
@@ -75,15 +94,30 @@ func scanDepFile(ctx context.Context, dir string) (bool, error) {
 		return false, e
 	}
 	for _, entry := range entries {
-		if entry.IsDir() {
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue //ignore hide file/folder
+		}
+		err := filepath.Walk(filepath.Join(dir, entry.Name()), func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() {
+				if strings.Contains(info.Name(), "requirement") {
+					waitingScanPipManagerFiles[info.Name()] = path
+				}
+				if info.Name() == "Dockerfile" {
+					parseDockerFile(dir, path, waitingScanPipManagerFiles)
+				}
+			}
+			return nil
+		})
+		if err != nil {
 			continue
 		}
-		var entryName = entry.Name()
-		if !strings.HasPrefix(entryName, "requirements") {
-			continue
-		}
-
-		fp := filepath.Join(dir, entryName)
+	}
+	logger.Info(fmt.Sprintf("total found pipManagerFiles:%d", len(waitingScanPipManagerFiles)))
+	for entryName, fp := range waitingScanPipManagerFiles {
+		logger.Info("start readRequirements...", zap.String("name", entryName), zap.String("relativePath", fp))
 		deps, e := readRequirements(fp)
 		if e != nil {
 			logger.Sugar().Errorf("Parse requirements file failed[%s]: %s", fp, e.Error())
@@ -208,4 +242,3 @@ func mergeComponentVersionOnly(target map[string]string, deps []model.Dependency
 		}
 	}
 }
-

--- a/module/python/python.go
+++ b/module/python/python.go
@@ -116,7 +116,7 @@ func scanDepFile(ctx context.Context, dir string) (bool, error) {
 			continue
 		}
 	}
-	logger.Info(fmt.Sprintf("total found pipManagerFiles: %d", len(waitingScanPipManagerFiles)))
+	logger.Sugar().Infof("total found pipManagerFiles: %d", len(waitingScanPipManagerFiles))
 	for entryName, fp := range waitingScanPipManagerFiles {
 		logger.Info("start readRequirements...", zap.String("name", entryName), zap.String("relativePath", fp))
 		deps, e := readRequirements(fp)

--- a/module/python/python.go
+++ b/module/python/python.go
@@ -101,13 +101,14 @@ func scanDepFile(ctx context.Context, dir string) (bool, error) {
 			if err != nil {
 				return err
 			}
-			if !info.IsDir() {
-				if strings.Contains(info.Name(), "requirement") {
-					waitingScanPipManagerFiles[info.Name()] = path
-				}
-				if info.Name() == "Dockerfile" {
-					parseDockerFile(dir, path, waitingScanPipManagerFiles)
-				}
+			if info.IsDir() {
+				return nil
+			}
+			if strings.Contains(info.Name(), "requirement") {
+				waitingScanPipManagerFiles[info.Name()] = path
+			}
+			if info.Name() == "Dockerfile" {
+				parseDockerFile(dir, path, waitingScanPipManagerFiles)
 			}
 			return nil
 		})

--- a/module/python/python.go
+++ b/module/python/python.go
@@ -52,7 +52,7 @@ func (i Inspector) CheckDir(dir string) bool {
 
 func parseDockerFile(dir, path string, m map[string]string) {
 	// find all PipManagerFiles from dockerfile
-	var regexpToFindPipManagerFiles = `.*?pip.*?install.*?-r[ ]*(.*?)\s+`
+	var regexpToFindPipManagerFiles = `pip\d?\s+install.*?\s-r\s+([^\s&|;"']+)`
 
 	data, err := os.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
hi,
在扫描python项目中发现部分项目未按规范定义依赖文件，具体表现:
1.生成的包依赖文件名随意,如xxx_requirement.txt、requirement.txt、install.txt等
2.包依赖文件不在项目根目录下,可能由于多环境部署，将多个包依赖文件统一放在某个文件夹下

以上场景目前扫描是发现不了包依赖文件而导致跳过.

优化项:
1.递归所有文件(非文件夹)判断是否包含关键字`requirement`
2.尝试发现`Dockerfile`,若存在,通过正则解析出待安装的包依赖文件名